### PR TITLE
Added a new dart api function to add the functionality to get just a …

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,9 +31,19 @@ class _MyAppState extends State<MyApp> {
             children: <Widget>[
               new MaterialButton(
                 color: Colors.blue,
-                child: new Text("CLICK ME"),
+                child: new Text("Phone"),
                 onPressed: () async {
                   Contact contact = await _contactPicker.selectContact();
+                  setState(() {
+                    _contact = contact;
+                  });
+                },
+              ),
+              new MaterialButton(
+                color: Colors.blue,
+                child: new Text("Contact"),
+                onPressed: () async {
+                  Contact contact = await _contactPicker.selectContactName();
                   setState(() {
                     _contact = contact;
                   });

--- a/lib/contact_picker.dart
+++ b/lib/contact_picker.dart
@@ -19,8 +19,19 @@ class ContactPicker {
   /// Returns the [Contact] selected by the user, or `null` if the user canceled
   /// out of the dialog.
   Future<Contact> selectContact() async {
+    return doSelect('phone');
+  }
+
+  Future<Contact> selectContactName() async {
+    return doSelect('contact');
+  }
+
+  Future<Contact> doSelect(String type) async {
+    final Map<String, dynamic> params = <String, dynamic> {
+      'type': type,
+    };
     final Map<dynamic, dynamic> result =
-        await _channel.invokeMethod('selectContact');
+        await _channel.invokeMethod('selectContact', params);
     if (result == null) {
       return null;
     }


### PR DESCRIPTION
…contact name. If you only need a contact name, the phone number picker shows a dialog with repeated contacts that have multiple phone numbers. This does not work well. The API uses parameters to tell the native platform which type is being requested.

The code was added for Android and not iOS. However, the iOS code should not break and simply gets the phone number as I cannot develop for iOS.